### PR TITLE
Properly handle indexer save on a SystemWipe

### DIFF
--- a/scripts/SystemWipe.te
+++ b/scripts/SystemWipe.te
@@ -1,5 +1,5 @@
 #REQUIRE KEYS
-is=["8000000000000120","80000000000000d1","8000000000000047"]
+is=["8000000000000120","8000000000000000"]
 p=println
 pr=print
 pe={pause() exit()}
@@ -24,6 +24,44 @@ pr("Deleting system saves... ")
 f=readdir("bis:/save")
 if(f.folders.len()!=0){p("Folders in save dir???")pe()}
 f.files.foreach("x"){if(!is.contains(x)){if(delfile("bis:/save/"+x)){p("File deletion failed: ", x)pe()}}}
+pr("Done!\nSetting up indexer save...")
+s=getfilesize("bis:/save/"+is[0])
+ba0=["BYTE[]",0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00]
+ba120=["BYTE[]",0x20,0x01,0x00,0x00,0x00,0x00,0x00,0x80]
+s1=s&0xFF
+s2=(s>>8)&0xFF
+s3=(s>>16)&0xFF
+s4=(s>>24)&0xFF
+idb=["BYTE[]",0x49,0x4D,0x4B,0x56,0x00,0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x49,0x4D,0x45,0x4E,0x40,0x00,0x00,0x00,0x40,0x00,0x00,0x00].copy()
+idb.addrange(ba0)
+idb.addrange(ba0)
+idb.addrange(ba0)
+idb.addrange(ba120)
+idb.addrange(ba0)
+idb.addrange(ba0)
+idb.addrange(ba0)
+idb.addrange(ba0)
+idb.addrange(ba120)
+idb.add(s1)
+idb.add(s2)
+idb.add(s3)
+idb.add(s4)
+idb.add(0x00)
+idb.add(0x00)
+idb.add(0x00)
+idb.add(0x00)
+idb.addrange(ba0)
+idb.addrange(ba0)
+idb.addrange(ba0)
+idb.addrange(ba0)
+idb.addrange(ba0)
+idb.addrange(ba0)
+idxs=readsave("bis:/save/"+is[1])
+if(idxs.resize("/imkvdb.arc",idb.len())){p("imkvdb resize failed")pe()}
+if(idxs.write("/imkvdb.arc",idb)){p("imkvdb write failed")pe()}
+if(idxs.resize("/lastPublishedId",ba0.len())){p("lastPublishedId resize failed")pe()}
+if(idxs.write("/lastPublishedId",ba0)){p("lastPublishedId write failed")pe()}
+if(idxs.commit()){p("Indexer save commit failed")pe()}
 pr("Done!\nDeleting user dirs...")ud=["Album","Contents","save","saveMeta","temp"]
 if(mount("USER")){p("Mount failed!")pe()}
 ud.foreach("x"){pr("\n"+x,"")if(deldir("bis:/"+x)){p("Dir deletion failed")pe()}mkdir("bis:/"+x)}

--- a/source/script/arrayClass.c
+++ b/source/script/arrayClass.c
@@ -65,6 +65,27 @@ int arrayClassAdd(Variable_t *caller, Variable_t *add){
 	return 0;
 }
 
+int arrayClassAddRange(Variable_t* caller, Variable_t* add)
+{
+	// Check if IntArrayClass or StringArrayClass or ByteArrayClass
+	if ((caller->variableType == IntArrayClass) || (caller->variableType == StringArrayClass) || (caller->variableType == ByteArrayClass)) {
+		if (caller->variableType != add->variableType) {
+			return 1;
+		}
+
+		for (s64 i = 0; i < add->solvedArray.vector.count; i++)
+		{
+			Variable_t v = arrayClassGetIdx(add, i);
+			if (arrayClassAdd(caller, &v))
+			{
+				return 1;
+			}
+		}
+	}
+
+	return 0;
+}
+
 ClassFunction(getArrayIdx) {
 	s64 getVal = (*args)->integer.value;
 	// Out of bounds
@@ -167,6 +188,20 @@ ClassFunction(arrayAdd) {
 	return &emptyClass;
 }
 
+ClassFunction(arrayAddRange) {
+	Variable_t* arg = *args;
+
+	if (caller->readOnly) {
+		SCRIPT_FATAL_ERR("Array is read-only");
+	}
+
+	if (arrayClassAddRange(caller, arg)) {
+		SCRIPT_FATAL_ERR("Adding the wrong type to a typed array");
+	}
+
+	return &emptyClass;
+}
+
 ClassFunction(arrayContains) {
 	Vector_t* v = &caller->solvedArray.vector;
 	Variable_t* arg = *args;
@@ -258,6 +293,7 @@ ClassFunctionTableEntry_t arrayFunctions[] = {
 	{"set", arraySet, 2, oneIntOneAny},
 	{"+", arrayAdd, 1, anotherAnotherOneVarArg},
 	{"add", arrayAdd, 1, anotherAnotherOneVarArg},
+	{"addrange", arrayAddRange, 1, anotherAnotherOneVarArg},
 	{"-", arrayMinus, 1, anotherOneIntArg},
 	{"contains", arrayContains, 1, anotherAnotherOneVarArg},
 	{"bytestostr", bytesToStr, 0, 0},

--- a/source/script/saveClass.c
+++ b/source/script/saveClass.c
@@ -5,6 +5,7 @@
 
 u8 oneStringArgSave[] = {StringClass};
 u8 oneStrOneByteArrayArgSave[] = {StringClass, ByteArrayClass};
+u8 oneStringOneIntArgSave[] = {StringClass, IntClass};
 
 ClassFunction(readFile){
     Variable_t *arg = (*args);
@@ -96,11 +97,25 @@ ClassFunction(saveClassCommit){
     return newIntVariablePtr(!save_commit(&caller->save->saveCtx));
 }
 
+ClassFunction(writeFileSize) {
+    Variable_t* arg = (*args);
+    save_data_file_ctx_t dataArc;
+    if (!save_open_file(&caller->save->saveCtx, &dataArc, arg->string.value, OPEN_MODE_WRITE))
+        return newIntVariablePtr(1);
+
+    if (!save_data_file_set_size(&dataArc, args[1]->integer.value)) {
+        return newIntVariablePtr(2);
+    };
+
+    return newIntVariablePtr(0);
+}
+
 ClassFunctionTableEntry_t saveFunctions[] = {
     {"read", readFile, 1, oneStringArgSave},
     {"write", writeFile, 2, oneStrOneByteArrayArgSave},
     //{"readdir", getFiles, 1, oneStringArgSave}, // Seems broken?
     {"commit", saveClassCommit, 0, 0},
+    {"resize", writeFileSize, 2, oneStringOneIntArgSave},
 };
 
 Variable_t getSaveMember(Variable_t* var, char* memberName) {

--- a/source/script/standardLibrary.c
+++ b/source/script/standardLibrary.c
@@ -399,6 +399,16 @@ ClassFunction(stdFileRead){
 	return copyVariableToPtr(v);
 }
 
+ClassFunction(stdFileReadSize) {
+	u32 fSize = 0;
+	u8* buff = sd_file_read(args[0]->string.value, &fSize);
+	if (buff == NULL) {
+		SCRIPT_FATAL_ERR("Failed to read file");
+	}
+
+	return newIntVariablePtr(fSize);
+}
+
 ClassFunction(stdFileWrite){
 	return newIntVariablePtr(sd_save_to_file(args[1]->solvedArray.vector.data, args[1]->solvedArray.vector.count, args[0]->string.value));	
 }
@@ -506,6 +516,7 @@ STUBBED(stdFileMove)
 STUBBED(stdLaunchPayload)
 STUBBED(stdFileWrite)
 STUBBED(stdFileRead)
+STUBBED(stdFileReadSize)
 STUBBED(stdCombinePaths)
 STUBBED(stdEmmcFileWrite)
 STUBBED(stdEmmcFileRead)
@@ -579,6 +590,7 @@ ClassFunctionTableEntry_t standardFunctionDefenitions[] = {
 	{"movefile", stdFileMove, 2, twoStringArgStd},
 	{"delfile", stdFileDel, 1, twoStringArgStd},
 	{"readfile", stdFileRead, 1, twoStringArgStd},
+	{"getfilesize", stdFileReadSize, 1, twoStringArgStd},
 	{"writefile", stdFileWrite, 2, oneStringOneByteArrayStd},
 	
 	// 	Utils


### PR DESCRIPTION
# Source
Changes in `source/script`
## arrayClass
Added `arrayClassAddRange` to add an array to an existing array.
## saveClass
Added `writeFileSize` to set the size of a file inside a save.
## standardLibrary.c
Added `stdFileReadSize` to get the size of a file.
# SystemWipe.te
- Don't keep the erpt and exfat saves anymore.
- Keep the indexer save and edit it so the 120 save is indexed.
